### PR TITLE
fix progress inconsistency after rebalance

### DIFF
--- a/src/main/kotlin/org/kafkalytic/plugin/ProgressDialog.kt
+++ b/src/main/kotlin/org/kafkalytic/plugin/ProgressDialog.kt
@@ -118,7 +118,7 @@ class OffsetsTableModel(val dialog: ProgressDialog, val topicName: String, priva
             consumerRemaining = groups.map { it.second.mapIndexed {i, o -> i to o}.toMap().toMutableMap() }
         }
         val rows = topicOffsets.mapIndexed { index, s -> mutableListOf(partitions[index], s).also {
-            it.addAll(consumers.mapIndexed { consumerIndex, consumerOffsets ->
+            it.addAll(consumers.filter { index + 1 < it.size }.mapIndexed { consumerIndex, consumerOffsets ->
                 val partitionIndex = index + 1
                 val currentOffset = consumerOffsets[partitionIndex]
                 val remaining = s.toLong() - currentOffset.toLong()


### PR DESCRIPTION
Fixes https://github.com/ermadan/kafkalytic/issues/20

Whenever there is a rebalance after increasing a topic's partition number to a higher value, there will be an interval of time where the consumer will not see the new partitions.

To prevent an error while monitoring the consumption progress, we now ignore the topic partitions until the consumer sees them.

More precisely, the issue would happen because the code traverses two collections that expects to be in sync. One includes the topic partitions and  the other one contains the consumer partitions. 

In this scenario, during some minutes following repartitioning, the consumer would not have an entry corresponding to the last entry in the topic collection. 

By filtering when not available, the problem solves on its own after a while.